### PR TITLE
Fixed non-working links to GSoC Repositories in .github's README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 # WELCOME TO RUXAILAB (aka Uramaki Lab)
 
-For a long time, the evaluation of user interfaces by user testing techniques, has been one of the most successful ways to get feedback from the users. HCI experts usually perform their experimental evaluations sessions in usability labs, indoor facilities with equiped with expensive and not available devices for everybody like eye-tracking devices or multi-rooms with specialised software.
+For a long time, the evaluation of user interfaces by user testing techniques has been one of the most successful ways to get feedback from the users. HCI experts usually perform their experimental evaluation sessions in usability labs, indoor facilities with equipped with expensive and not available devices for everybody, like eye-tracking devices or multi-rooms with specialised software.
 
 The main goal of RUXAILAB is to create a set of open-source toolchains that helps to perform usability tests in a remote environment based on Artificial Intelligence. Our core is a system that allows to do remote heuristic tests and share the studies to other participants, creating at the same time a social network of developers who wants to get in touch with the studies of their colleagues.
 
@@ -12,16 +12,16 @@ Feel free to report bugs, suggest features or work on existing ones to any of th
 
 **Some issues guidelines for an easygoing communication**
 
-We work with and assignee system. So you need to express your interest to work on the issue. The first to express interest in the issue comments will have the preference, but be aware to understand what you have to do first and make sure you will have the time and dedication for that before expressing interest, so others also have the chance :wink: 
+We work with an assignee system. So you need to express your interest to work on the issue. The first to express interest in the issue comments will have the preference, but be aware to understand what you have to do first and make sure you will have the time and dedication for that before expressing interest, so others also have the chance :wink: 
 
-The person who raised an issue would have the preference to fix it, if the person do not want to or takes too long to answer back, we open it for others.
+The person who raised an issue would have the preference to fix it, if the person does not want to or takes too long to answer back, we open it for others.
 
 ### Google Summer of Code 2025
 
-RUXAILAB would like to express his interest to participate on the 2025 edition. For this reason we are asking our community to help us to determinate the project proposals that you are most interested in. So many contributors appeared during the last year and now it is time to join us to co-create the features for 2025. We appreciate your work and enthusiasm and we would like that you came in touch with the community.
-In our organization, we value people who are proactive, hardworking and that sees always the big picture, thinking about how their work can contribute to the community and to the open source world, thus it is a good idea to start collaborating with us early so we can get to know you better.
+RUXAILAB would like to express its interest to participate on the 2025 edition. For this reason, we are asking our community to help us to determinate the project proposals that you are most interested in. So many contributors appeared during the last year, and now it is time to join us to co-create the features for 2025. We appreciate your work and enthusiasm, and we would like that you came in touch with the community.
+In our organization, we value people who are proactive, hardworking, and who always see the big picture, thinking about how their work can contribute to the community and to the open source world, thus it is a good idea to start collaborating with us early so we can get to know you better.
 
-Read carefully the project idea page on the [gsoc repository]([https://github.com/ruxailab/gsoc](https://github.com/ruxailab/gsoc/blob/main/ideas2025.md)) and get in touch with us throught the different communication channels available!
+Read carefully the project idea page on the [GSoC repository](https://github.com/ruxailab/gsoc) and [GSoC 2025 ideas](https://github.com/ruxailab/gsoc/blob/main/ideas2025.md) and get in touch with us through the different communication channels available!
 
 ## Communication channels
 


### PR DESCRIPTION
The previous code only shows the words without the link, it is fixed in this commit. Some minor grammatical mistakes are also fixed along the way.